### PR TITLE
bond: default linksInContainer to true, deprecate false

### DIFF
--- a/bond/bond.go
+++ b/bond/bond.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"runtime"
 	"strconv"
 
@@ -39,7 +40,7 @@ import (
 type bondingConfig struct {
 	types.NetConf
 	Mode        string                   `json:"mode"`
-	LinksContNs bool                     `json:"linksInContainer"`
+	LinksContNs *bool                    `json:"linksInContainer"`
 	FailOverMac int                      `json:"failOverMac"`
 	Miimon      string                   `json:"miimon"`
 	Links       []map[string]interface{} `json:"links"`
@@ -95,6 +96,14 @@ func loadConfigFile(bytes []byte) (*bondingConfig, string, error) {
 
 	if bondConf.XmitHashPolicy != nil && netlink.StringToBondXmitHashPolicy(*bondConf.XmitHashPolicy) == netlink.BOND_XMIT_HASH_POLICY_UNKNOWN {
 		return nil, "", fmt.Errorf("xmitHashPolicy is not supported, actual: %+v", *bondConf.XmitHashPolicy)
+	}
+
+	if bondConf.LinksContNs == nil {
+		t := true
+		bondConf.LinksContNs = &t
+	} else if !*bondConf.LinksContNs {
+		fmt.Fprintf(os.Stderr, "bond-cni: linksInContainer: false is deprecated; "+
+			"use a chained plugin (host-device, SR-IOV) to bring interfaces into the pod netns\n")
 	}
 
 	return bondConf, bondConf.CNIVersion, nil
@@ -298,7 +307,7 @@ func createBond(bondName string, bondConf *bondingConfig, nspath string, ns ns.N
 	}
 	defer netNsHandle.Close()
 
-	if !bondConf.LinksContNs {
+	if !*bondConf.LinksContNs {
 		if err := setLinksInNetNs(bondConf, nspath, false); err != nil {
 			return nil, fmt.Errorf("failed to move the links (%+v) in container network namespace, error: %+v", bondConf.Links, err)
 		}
@@ -479,7 +488,7 @@ func cmdDel(args *skel.CmdArgs) error {
 		return fmt.Errorf("failed to delete bonded link (%+v), error: %+v", linkObjToDel.Attrs().Name, err)
 	}
 
-	if !bondConf.LinksContNs {
+	if !*bondConf.LinksContNs {
 		if err := setLinksInNetNs(bondConf, args.Netns, true); err != nil {
 			return fmt.Errorf("failed set links (%+v) in host network namespace, error: %+v", bondConf.Links, err)
 		}

--- a/bond/bond_test.go
+++ b/bond/bond_test.go
@@ -747,6 +747,52 @@ var _ = Describe("bond plugin", func() {
 	})
 })
 
+var _ = Describe("loadConfigFile", func() {
+	var baseConfig = `{
+		"name": "bond",
+		"type": "bond",
+		"cniVersion": "1.0.0",
+		"mode": "active-backup",
+		"failOverMac": 1,
+		"miimon": "100",
+		"links": [
+			{"name": "net1"},
+			{"name": "net2"}
+		]
+	}`
+
+	When("linksInContainer is not set in config", func() {
+		It("must default to true and succeed", func() {
+			bondConf, _, err := loadConfigFile([]byte(baseConfig))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(bondConf.LinksContNs).NotTo(BeNil())
+			Expect(*bondConf.LinksContNs).To(BeTrue())
+		})
+	})
+
+	When("linksInContainer is explicitly false", func() {
+		It("must succeed and emit deprecation warning", func() {
+			config := `{
+				"name": "bond",
+				"type": "bond",
+				"cniVersion": "1.0.0",
+				"mode": "active-backup",
+				"failOverMac": 1,
+				"miimon": "100",
+				"linksInContainer": false,
+				"links": [
+					{"name": "net1"},
+					{"name": "net2"}
+				]
+			}`
+			bondConf, _, err := loadConfigFile([]byte(config))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(bondConf.LinksContNs).NotTo(BeNil())
+			Expect(*bondConf.LinksContNs).To(BeFalse())
+		})
+	})
+})
+
 func addLinksInNS(initNS ns.NetNS, links []netlink.LinkAttrs) {
 	for _, link := range links {
 		var err error


### PR DESCRIPTION
Closes #207

## What

Change `LinksContNs` from `bool` to `*bool` to distinguish an omitted
`linksInContainer` field from an explicit `false`.

- Omitted → defaults to `true` (links already in pod netns — the safe path)
- Explicit `true` → unchanged
- Explicit `false` → works but emits a deprecation warning to stderr

## Why

When `linksInContainer` was a plain `bool`, omitting it silently defaulted
to `false`, causing bond-cni to enter the host network namespace and move
whatever interfaces the tenant named into their pod — with no validation.

The recommended pattern is to use a chained plugin (host-device, SR-IOV
device plugin) to place interfaces into the pod netns first, then let
bond-cni act as a pure meta-plugin operating entirely within the pod netns.
Defaulting to `true` makes the safe path require no configuration change.
Explicit `false` is preserved for existing deployments but marked deprecated.

## Breaking change

Deployments that omit `linksInContainer` and rely on the implicit host-netns
link movement will now get `linksInContainer: true` behaviour. Set
`linksInContainer: false` explicitly to preserve the old behaviour until it
is removed in a future version.